### PR TITLE
Remove `--paper-button-disabled` mixin blocking

### DIFF
--- a/spine-button.html
+++ b/spine-button.html
@@ -42,6 +42,10 @@ All default `paper-button` mixins are available for styling.
         @apply --spine-button-raised-hover;
       }
 
+      :host([raised][disabled]) {
+        @apply --paper-button-disabled;
+      }
+
       span {
         @apply --spine-button-content;
       }


### PR DESCRIPTION
This PR fixes an issue with blocking `--paper-button-disabled` mixin.
The crux of the problem is that `--spine-button-raised` mixin has a higher priority than `--paper-button-disabled` which is not correct.

@dkalinin PTAL